### PR TITLE
Harden deployment configs with baseline web security headers

### DIFF
--- a/gatsby-landing.firebase.json
+++ b/gatsby-landing.firebase.json
@@ -1,11 +1,46 @@
 {
   "hosting": {
     "public": "dist/public",
-    "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
+    "ignore": [
+      "firebase.json",
+      "**/.*",
+      "**/node_modules/**"
+    ],
     "rewrites": [
       {
         "source": "**/**",
         "destination": "/index.html"
+      }
+    ],
+    "headers": [
+      {
+        "source": "**",
+        "headers": [
+          {
+            "key": "Content-Security-Policy",
+            "value": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com https://www.google-analytics.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; img-src 'self' data: https:; connect-src 'self' https://www.google-analytics.com https://stats.g.doubleclick.net; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
+          },
+          {
+            "key": "Referrer-Policy",
+            "value": "strict-origin-when-cross-origin"
+          },
+          {
+            "key": "X-Content-Type-Options",
+            "value": "nosniff"
+          },
+          {
+            "key": "X-Frame-Options",
+            "value": "DENY"
+          },
+          {
+            "key": "Permissions-Policy",
+            "value": "camera=(), microphone=(), geolocation=()"
+          },
+          {
+            "key": "Strict-Transport-Security",
+            "value": "max-age=31536000; includeSubDomains; preload"
+          }
+        ]
       }
     ]
   }

--- a/gatsby-landing.now.json
+++ b/gatsby-landing.now.json
@@ -5,16 +5,23 @@
     {
       "src": "packages/landing-gatsby/package.json",
       "use": "@now/static-build",
-      "config": { "distDir": "public" }
+      "config": {
+        "distDir": "public"
+      }
     }
   ],
   "routes": [
     {
       "src": "/(.*)",
-      "dest": "/packages/landing-gatsby/$1",
       "headers": {
-        "x-request-path": "$1"
-      }
+        "Content-Security-Policy": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com https://www.google-analytics.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; img-src 'self' data: https:; connect-src 'self' https://www.google-analytics.com https://stats.g.doubleclick.net; frame-ancestors 'none'; base-uri 'self'; form-action 'self'",
+        "Referrer-Policy": "strict-origin-when-cross-origin",
+        "X-Content-Type-Options": "nosniff",
+        "X-Frame-Options": "DENY",
+        "Permissions-Policy": "camera=(), microphone=(), geolocation=()",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload"
+      },
+      "dest": "/packages/landing-gatsby/$1"
     }
   ]
 }

--- a/landing.firebase.json
+++ b/landing.firebase.json
@@ -1,11 +1,46 @@
 {
   "hosting": {
     "public": "dist/public",
-    "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
+    "ignore": [
+      "firebase.json",
+      "**/.*",
+      "**/node_modules/**"
+    ],
     "rewrites": [
       {
         "source": "**/**",
         "function": "next"
+      }
+    ],
+    "headers": [
+      {
+        "source": "**",
+        "headers": [
+          {
+            "key": "Content-Security-Policy",
+            "value": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com https://www.google-analytics.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; img-src 'self' data: https:; connect-src 'self' https://www.google-analytics.com https://stats.g.doubleclick.net; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
+          },
+          {
+            "key": "Referrer-Policy",
+            "value": "strict-origin-when-cross-origin"
+          },
+          {
+            "key": "X-Content-Type-Options",
+            "value": "nosniff"
+          },
+          {
+            "key": "X-Frame-Options",
+            "value": "DENY"
+          },
+          {
+            "key": "Permissions-Policy",
+            "value": "camera=(), microphone=(), geolocation=()"
+          },
+          {
+            "key": "Strict-Transport-Security",
+            "value": "max-age=31536000; includeSubDomains; preload"
+          }
+        ]
       }
     ]
   },

--- a/landing.now.json
+++ b/landing.now.json
@@ -2,15 +2,23 @@
   "name": "react-next-landing",
   "version": 2,
   "builds": [
-    { "src": "packages/landing/package.json", "use": "@now/static-build" }
+    {
+      "src": "packages/landing/package.json",
+      "use": "@now/static-build"
+    }
   ],
   "routes": [
     {
       "src": "/(.*)",
-      "dest": "/packages/landing/$1",
       "headers": {
-        "x-request-path": "$1"
-      }
+        "Content-Security-Policy": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com https://www.google-analytics.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; img-src 'self' data: https:; connect-src 'self' https://www.google-analytics.com https://stats.g.doubleclick.net; frame-ancestors 'none'; base-uri 'self'; form-action 'self'",
+        "Referrer-Policy": "strict-origin-when-cross-origin",
+        "X-Content-Type-Options": "nosniff",
+        "X-Frame-Options": "DENY",
+        "Permissions-Policy": "camera=(), microphone=(), geolocation=()",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload"
+      },
+      "dest": "/packages/landing/$1"
     }
   ]
 }

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,6 +4,15 @@
   command = "yarn gatsby-build"
 
 [build.environment]
-  YARN_VERSION = "1.12.1"
-  NODE_VERSION = "12.13.1"
-  
+  YARN_VERSION = "1.22.22"
+  NODE_VERSION = "20.18.0"
+
+[[headers]]
+  for = "/*"
+  [headers.values]
+    Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com https://www.google-analytics.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; img-src 'self' data: https:; connect-src 'self' https://www.google-analytics.com https://stats.g.doubleclick.net; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
+    Referrer-Policy = "strict-origin-when-cross-origin"
+    X-Content-Type-Options = "nosniff"
+    X-Frame-Options = "DENY"
+    Permissions-Policy = "camera=(), microphone=(), geolocation=()"
+    Strict-Transport-Security = "max-age=31536000; includeSubDomains; preload"


### PR DESCRIPTION
### Motivation
- Deployment configuration files lacked consistent security response headers and used outdated pinned build runtimes, leaving clients exposed to common browser attack surfaces and EOL toolchains.
- The change introduces a minimal, opinionated baseline of headers to reduce risk for static and server-backed hosting targets.

### Description
- Added a consistent set of response headers (`Content-Security-Policy`, `Referrer-Policy`, `X-Content-Type-Options`, `X-Frame-Options`, `Permissions-Policy`, `Strict-Transport-Security`) to `netlify.toml`, `gatsby-landing.firebase.json`, and `landing.firebase.json` to provide baseline browser protections.
- Injected the same headers into the Vercel/Now route configs (`gatsby-landing.now.json`, `landing.now.json`) and removed the reflective `x-request-path` response header.
- Updated Netlify build runtime pins in `netlify.toml` to modern supported versions (`NODE_VERSION=20.18.0`, `YARN_VERSION=1.22.22`) to avoid building on legacy/EOL toolchains.
- Ensured all modified JSON/TOML files remain syntactically valid after edits.

### Testing
- Validated JSON files with `python3 -m json.tool` which succeeded for the modified files.
- Confirmed presence of the new headers via a repository search using `rg` which returned the expected header keys and values.
- Attempted a dependency audit with `yarn npm audit --severity moderate` which failed due to an upstream `403` from the registry in this environment and is therefore inconclusive for dependency issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a81483c1dc832aad4e085b5ea502fa)